### PR TITLE
add Hardware AppType (I think this is used for the Steam Deck)

### DIFF
--- a/SteamPrefill/Models/Enums/AppType.cs
+++ b/SteamPrefill/Models/Enums/AppType.cs
@@ -15,6 +15,7 @@ namespace SteamPrefill.Models.Enums
         public static readonly AppType Dlc = new AppType("dlc");
         public static readonly AppType Game = new AppType("game");
         public static readonly AppType Guide = new AppType("guide");
+        public static readonly AppType Hardware = new AppType("hardware");
         public static readonly AppType Media = new AppType("media");
         public static readonly AppType Music = new AppType("music");
         public static readonly AppType Series = new AppType("series");


### PR DESCRIPTION
Fixes the following error:

```
[12:32:27 PM] Logged into Steam
[12:32:28 PM] Steam session initialization complete!
System.FormatException: hardware is not a valid enum value for AppType!
  at T SteamPrefill.Models.Enums.EnumBase`1.Parse(string toParse)
  at T SteamPrefill.Utils.KeyValueExtensions.AsEnum<T>(KeyValue keyValue, bool toLower)
  at SteamPrefill.Models.AppInfo..ctor(Steam3Session steamSession, uint appId, KeyValue rootKeyValue)
  at async Task SteamPrefill.Handlers.AppInfoHandler.BulkLoadAppInfosAsync(List<uint> appIds)
  at void SteamPrefill.SteamManager.<>c__DisplayClass13_0.<<RetrieveAppMetadataAsync>b__0>d.MoveNext()
  at void Spectre.Console.Status.<>c__DisplayClass16_0.<<StartAsync>b__0>d.MoveNext() in Status.cs:79
  at void Spectre.Console.Status.<>c__DisplayClass17_0`1.<<StartAsync>b__0>d.MoveNext() in Status.cs:120
  at void Spectre.Console.Progress.<>c__DisplayClass28_0`1.<<StartAsync>b__0>d.MoveNext() in Progress.cs:133
  at async Task<T> Spectre.Console.Internal.DefaultExclusivityMode.RunAsync<T>(Func<Task<T>> func) in
     DefaultExclusivityMode.cs:40
  at async Task<T> Spectre.Console.Progress.StartAsync<T>(Func<ProgressContext, Task<T>> action) in Progress.cs:116
  at async Task<T> Spectre.Console.Status.StartAsync<T>(string status, Func<StatusContext, Task<T>> func) in Status.cs:
     117
  at async Task Spectre.Console.Status.StartAsync(string status, Func<StatusContext, Task> action) in Status.cs:77
  at async Task SteamPrefill.SteamManager.RetrieveAppMetadataAsync(List<uint> appIds)
  at async Task SteamPrefill.SteamManager.SelectAppsAsync()
  at async ValueTask SteamPrefill.CliCommands.SelectAppsCommand.ExecuteAsync(IConsole console)
```