### PR TITLE
Adding a check to see if a depot's owning app is invalid.  This means…

### DIFF
--- a/SteamPrefill/Handlers/DepotHandler.cs
+++ b/SteamPrefill/Handlers/DepotHandler.cs
@@ -71,6 +71,12 @@
                     continue;
                 }
 
+                AppInfo containingApp = _appInfoHandler.GetAppInfoAsync(depot.ContainingAppId).Result;
+                if (containingApp.IsInvalidApp)
+                {
+                    continue;
+                }
+
                 // Filtering to only specified operating systems
                 if (depot.SupportedOperatingSystems.Any() && !depot.SupportedOperatingSystems.Contains(downloadArgs.OperatingSystem))
                 {

--- a/SteamPrefill/Models/AppInfo.cs
+++ b/SteamPrefill/Models/AppInfo.cs
@@ -53,6 +53,8 @@
         /// </summary>
         public AppType Type { get; }
 
+        public bool IsInvalidApp => Type == null;
+
         public bool IsFreeGame { get; set; }
 
         public int? MinutesPlayed2Weeks { get; set; }


### PR DESCRIPTION
… the depot needs to be skipped, as it will be unable to be downloaded.