### PR TITLE
#135 Added cellId support and logging of total returned CDN servers in RELEASE

### DIFF
--- a/SteamPrefill/CliCommands/SelectAppsCommand.cs
+++ b/SteamPrefill/CliCommands/SelectAppsCommand.cs
@@ -22,6 +22,35 @@ namespace SteamPrefill.CliCommands
                                                     .Title(LightYellow("Run prefill now?"))
                                                     .AddChoices(true, false)
                                                     .UseConverter(e => e == false ? "No" : "Yes"));
+
+                uint? cellId = ansiConsole.Prompt(new SelectionPrompt<uint?>()
+                    .Title(LightYellow("Select Download Region:"))
+                    .AddChoices(new uint?[] { 1, 5, 9, null }) //Maybe random from https://github.com/tpill90/steam-lancache-prefill/issues/135#issuecomment-1264783642
+                    .UseConverter(e => {
+                        if (e == 9)
+                        {
+                            return "SEA";
+                        }
+                        else if (e == 5)
+                        {
+                            return "Europe";
+                        }
+                        else if (e == 1)
+                        {
+                            return "Americas";
+                        }
+                        else
+                        {
+                            return null;
+                        }
+                    }));
+
+                if (cellId.HasValue)
+                {
+                    File.Delete(AppConfig.UserSelectedCellId);
+                    await File.WriteAllTextAsync(AppConfig.UserSelectedCellId, cellId.ToString());
+                }
+
                 if (runPrefill)
                 {
                     await steamManager.DownloadMultipleAppsAsync(false, false, null, new List<uint>());

--- a/SteamPrefill/Handlers/DownloadHandler.cs
+++ b/SteamPrefill/Handlers/DownloadHandler.cs
@@ -53,6 +53,7 @@
                 // Handle any failed requests
                 while (failedRequests.Any() && retryCount < 3)
                 {
+                    await _cdnPool.PopulateAvailableServersAsync();
                     retryCount++;
                     await Task.Delay(2000 * retryCount);
                     failedRequests = await AttemptDownloadAsync(ctx, $"Retrying  {retryCount}..", failedRequests.ToList());

--- a/SteamPrefill/Handlers/DownloadHandler.cs
+++ b/SteamPrefill/Handlers/DownloadHandler.cs
@@ -53,7 +53,6 @@
                 // Handle any failed requests
                 while (failedRequests.Any() && retryCount < 3)
                 {
-                    await _cdnPool.PopulateAvailableServersAsync();
                     retryCount++;
                     await Task.Delay(2000 * retryCount);
                     failedRequests = await AttemptDownloadAsync(ctx, $"Retrying  {retryCount}..", failedRequests.ToList());

--- a/SteamPrefill/Handlers/Steam/CdnPool.cs
+++ b/SteamPrefill/Handlers/Steam/CdnPool.cs
@@ -8,6 +8,7 @@ namespace SteamPrefill.Handlers.Steam
     {
         private readonly IAnsiConsole _ansiConsole;
         private readonly Steam3Session _steamSession;
+        private uint? _cellId;
         
         private List<Server> _availableServerEndpoints = new List<Server>();
         private int _minimumServerCount = 10;
@@ -19,13 +20,17 @@ namespace SteamPrefill.Handlers.Steam
             _steamSession = steamSession;
         }
 
+        public void setCellId(uint? cellId)
+        {
+            _cellId = cellId;
+        }
+
         /// <summary>
         /// Gets a list of available CDN servers from the Steam network.
         /// Required to be called prior to using the class.
         /// </summary>
-        /// <param name="cellId">The cellId to get Caching Servers from</param>
         /// <exception cref="CdnExhaustionException">If no servers are available for use, this exception will be thrown.</exception>
-        public async Task PopulateAvailableServersAsync(uint? cellId)
+        public async Task PopulateAvailableServersAsync()
         {
             //TODO need to add a timeout to this GetServersForSteamPipe() call
             if (_availableServerEndpoints.Count >= _minimumServerCount)
@@ -41,7 +46,7 @@ namespace SteamPrefill.Handlers.Steam
                 while (_availableServerEndpoints.Count < _minimumServerCount && retryCount < _maxRetries)
                 {
                     int countBefore = _availableServerEndpoints.Count;
-                    var returnedServers = await _steamSession.SteamContent.GetServersForSteamPipe(cellId);
+                    var returnedServers = await _steamSession.SteamContent.GetServersForSteamPipe(_cellId);
                     totalServers += returnedServers.Count;
                     _availableServerEndpoints.AddRange(returnedServers);
 #if DEBUG

--- a/SteamPrefill/Handlers/Steam/CdnPool.cs
+++ b/SteamPrefill/Handlers/Steam/CdnPool.cs
@@ -18,13 +18,14 @@ namespace SteamPrefill.Handlers.Steam
             _ansiConsole = ansiConsole;
             _steamSession = steamSession;
         }
-        
+
         /// <summary>
         /// Gets a list of available CDN servers from the Steam network.
         /// Required to be called prior to using the class.
         /// </summary>
+        /// <param name="cellId">The cellId to get Caching Servers from</param>
         /// <exception cref="CdnExhaustionException">If no servers are available for use, this exception will be thrown.</exception>
-        public async Task PopulateAvailableServersAsync()
+        public async Task PopulateAvailableServersAsync(uint? cellId)
         {
             //TODO need to add a timeout to this GetServersForSteamPipe() call
             if (_availableServerEndpoints.Count >= _minimumServerCount)
@@ -32,22 +33,33 @@ namespace SteamPrefill.Handlers.Steam
                 return;
             }
 
-            await _ansiConsole.StatusSpinner().StartAsync("Getting available CDNs", async _ =>
+            string statusString = string.Concat(Grey("{0}"), White(" Getting available CDNs "), Green("{1}/{2}"));
+            await _ansiConsole.StatusSpinner().StartAsync(string.Format(statusString, 0, 0, _minimumServerCount), async task =>
             {
                 var retryCount = 0;
                 while (_availableServerEndpoints.Count < _minimumServerCount && retryCount < _maxRetries)
                 {
-                    var allServers = await _steamSession.SteamContent.GetServersForSteamPipe();
-                    _availableServerEndpoints.AddRange(allServers);
-
+                    int countBefore = _availableServerEndpoints.Count;
+                    var availableServers = await _steamSession.SteamContent.GetServersForSteamPipe(cellId);
+                    _availableServerEndpoints.AddRange(availableServers);
+#if DEBUG
+                    _ansiConsole.MarkupLine(White("Retry ") + Green(retryCount));
+                    foreach (Server server in _availableServerEndpoints)
+                    {
+                        _ansiConsole.MarkupLine(White(string.Format("{0} {1}", MediumPurple(server.Host), White(server.Type))));
+                    }
+#endif
                     // Filtering out non-cacheable cdns, and duplicate hosts
-                    _availableServerEndpoints = _availableServerEndpoints.Where(e => e.Type == "SteamCache" && e.AllowedAppIds.Length == 0)
-                                                                         .DistinctBy(e => e.Host)
-                                                                         .ToList();
+                    _availableServerEndpoints = _availableServerEndpoints
+                        .Where(e => e.Type == "SteamCache" && e.AllowedAppIds.Length == 0) //TODO AllowedAppIds Documentation??
+                        .DistinctBy(e => e.Host)
+                        .ToList();
 
                     // Will wait increasingly longer periods when re-trying
                     retryCount++;
                     await Task.Delay(retryCount * 100);
+                    task.Status(string.Format(statusString, retryCount, _availableServerEndpoints.Count, _minimumServerCount));
+                    task.Refresh();
                 }
             });
 

--- a/SteamPrefill/Settings/AppConfig.cs
+++ b/SteamPrefill/Settings/AppConfig.cs
@@ -35,5 +35,6 @@ namespace SteamPrefill.Settings
 
         public static readonly string AccountSettingsStorePath = Path.Combine(ConfigDir, "account.config");
         public static readonly string UserSelectedAppsPath = Path.Combine(ConfigDir, "selectedAppsToPrefill.json");
+        public static readonly string UserSelectedCellId = Path.Combine(ConfigDir, "cellId.config");
     }
 }

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -147,10 +147,11 @@
 
             //If Download Region Configured -> load
             uint? cellId = LoadSelectedCellId();
+            _cdnPool.setCellId(cellId);
 
             _ansiConsole.LogMarkupLine($"Starting {Cyan(appInfo)}");
 
-            await _cdnPool.PopulateAvailableServersAsync(cellId);
+            await _cdnPool.PopulateAvailableServersAsync();
 
             // Get the full file list for each depot, and queue up the required chunks
             var chunkDownloadQueue = await BuildChunkDownloadQueueAsync(filteredDepots);

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -27,7 +27,7 @@
                 DebugLog.Enabled = true;
             }
 #endif
-            
+
             _steam3 = new Steam3Session(_ansiConsole);
             _cdnPool = new CdnPool(_ansiConsole, _steam3);
             _appInfoHandler = new AppInfoHandler(_ansiConsole, _steam3);
@@ -145,9 +145,12 @@
                 return;
             }
 
+            //If Download Region Configured -> load
+            uint? cellId = LoadSelectedCellId();
+
             _ansiConsole.LogMarkupLine($"Starting {Cyan(appInfo)}");
 
-            await _cdnPool.PopulateAvailableServersAsync();
+            await _cdnPool.PopulateAvailableServersAsync(cellId);
 
             // Get the full file list for each depot, and queue up the required chunks
             var chunkDownloadQueue = await BuildChunkDownloadQueueAsync(filteredDepots);
@@ -247,6 +250,15 @@
                 return JsonSerializer.Deserialize(File.ReadAllText(AppConfig.UserSelectedAppsPath), SerializationContext.Default.ListUInt32);
             }
             return new List<uint>();
+        }
+
+        public uint? LoadSelectedCellId()
+        {
+            if (File.Exists(AppConfig.UserSelectedCellId))
+            {
+                return System.Convert.ToUInt32(File.ReadAllText(AppConfig.UserSelectedCellId));
+            }
+            return null;
         }
 
         public async Task<List<AppInfo>> GetAllAvailableGamesAsync()

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -147,11 +147,10 @@
 
             //If Download Region Configured -> load
             uint? cellId = LoadSelectedCellId();
-            _cdnPool.setCellId(cellId);
 
             _ansiConsole.LogMarkupLine($"Starting {Cyan(appInfo)}");
 
-            await _cdnPool.PopulateAvailableServersAsync();
+            await _cdnPool.PopulateAvailableServersAsync(cellId);
 
             // Get the full file list for each depot, and queue up the required chunks
             var chunkDownloadQueue = await BuildChunkDownloadQueueAsync(filteredDepots);


### PR DESCRIPTION
Not perfect yet as selected cellIds are `1, 5, 9` for NA, EU, SEA respectively instead of [reference](https://github.com/tpill90/steam-lancache-prefill/issues/135#issuecomment-1264783642).
Selection occurs when apps-select is executed and value stored in `Config/cellId.config`.

Also added the total amount of responses to the error message to avoid implication of "0 response from Steam"