### PR TITLE
The expiration logic for free weekend games was using the current tim…

### DIFF
--- a/SteamPrefill/Handlers/Steam/Steam3Session.cs
+++ b/SteamPrefill/Handlers/Steam/Steam3Session.cs
@@ -411,7 +411,7 @@ namespace SteamPrefill.Handlers.Steam
                 if (freeWeekend != KeyValue.Invalid && freeWeekend.AsBoolean())
                 {
                     var expiryTimeUtc = package.KeyValues["extended"]["expirytime"].AsDateTimeUtc();
-                    if (DateTime.Now > expiryTimeUtc)
+                    if (DateTime.UtcNow > expiryTimeUtc)
                     {
                         continue;
                     }
@@ -421,9 +421,9 @@ namespace SteamPrefill.Handlers.Steam
                 {
                     OwnedAppIds.Add(UInt32.Parse(appId.Value));
                 }
-                foreach (KeyValue appId in package.KeyValues["depotids"].Children)
+                foreach (KeyValue depotId in package.KeyValues["depotids"].Children)
                 {
-                    OwnedDepotIds.Add(UInt32.Parse(appId.Value));
+                    OwnedDepotIds.Add(UInt32.Parse(depotId.Value));
                 }
             }
 
@@ -442,9 +442,9 @@ namespace SteamPrefill.Handlers.Steam
                 {
                     OwnedAppIds.Add(UInt32.Parse(appId.Value));
                 }
-                foreach (KeyValue appId in package.KeyValues["depotids"].Children)
+                foreach (KeyValue depotId in package.KeyValues["depotids"].Children)
                 {
-                    OwnedDepotIds.Add(UInt32.Parse(appId.Value));
+                    OwnedDepotIds.Add(UInt32.Parse(depotId.Value));
                 }
             }
 

--- a/SteamPrefill/Models/DepotInfo.cs
+++ b/SteamPrefill/Models/DepotInfo.cs
@@ -7,10 +7,6 @@
 
         public ulong? ManifestId { get; set; }
 
-        /*
-         * TODO The _originalAppId was added in here to avoid file lock exceptions when writing shared depot manifests in parallel.
-         * This could possibly add up to a non-trivial amount of duplicated storage
-         */
         public string ManifestFileName => $"{AppConfig.CacheDir}/{_originalAppId}_{ContainingAppId}_{DepotId}_{ManifestId}.bin";
 
         /// <summary>


### PR DESCRIPTION
…ezone instead of UTC, thus causing free weekend games to fail manifest downloads since they are incorrectly considered as owned.