### PR TITLE
Fixing a scenario where an App has a DLC app, but that DLC app owns n…

### DIFF
--- a/SteamPrefill.sln
+++ b/SteamPrefill.sln
@@ -9,8 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\actions.yml = .github\workflows\actions.yml
 		commands.json = commands.json
-		docs\Development.md = docs\Development.md
-		publish.ps1 = publish.ps1
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/SteamPrefill/Properties/GlobalUsings.cs
+++ b/SteamPrefill/Properties/GlobalUsings.cs
@@ -38,7 +38,6 @@ global using System.Net.Http;
 global using System.Runtime.InteropServices;
 global using System.Runtime.Serialization;
 global using System.Security.Cryptography;
-global using System.Text;
 global using System.Text.Json;
 global using System.Text.Json.Serialization;
 global using System.Threading.Tasks;
@@ -50,4 +49,5 @@ global using AnsiConsoleExtensions = LancachePrefill.Common.Extensions.AnsiConso
 global using PicsProductInfo = SteamKit2.SteamApps.PICSProductInfoCallback.PICSProductInfo;
 global using Architecture = SteamPrefill.Models.Enums.Architecture;
 global using OperatingSystem = SteamPrefill.Models.Enums.OperatingSystem;
+global using static SteamKit2.SteamApps;
 global using System.Security.Authentication;

--- a/commands.json
+++ b/commands.json
@@ -8,12 +8,12 @@
     "Open debug folder": {
       "fileName": "explorer.exe",
       "workingDirectory": ".",
-      "arguments": "C:\\Users\\Tim\\Dropbox\\Programming\\dotnet-public\\SteamPrefill\\SteamPrefill\\bin\\Debug\\net6.0"
+      "arguments": "SteamPrefill\\bin\\Debug\\net6.0"
     },
     "Open release folder": {
       "fileName": "explorer.exe",
       "workingDirectory": ".",
-      "arguments": "C:\\Users\\Tim\\Dropbox\\Programming\\dotnet-public\\SteamPrefill\\SteamPrefill\\bin\\Release\\net6.0"
+      "arguments": "SteamPrefill\\bin\\Release\\net6.0"
     },
     "Open cache folder": {
       "fileName": "explorer.exe",


### PR DESCRIPTION
…o depots of its own.

Instead the parent App owns a depot with a DepotId that's the same as the DLC App's AppId. This means that the user actually owns the depot.