### PR TITLE
Changing the way manifests are downloaded from parallel to serial.  T…

### DIFF
--- a/LancachePrefill.Common/FileLogger.cs
+++ b/LancachePrefill.Common/FileLogger.cs
@@ -7,7 +7,7 @@
         //TODO need to move this over to using a logging library, rather than doing this manually
         public static void Log(string message)
         {
-            File.AppendAllText(_logFilePath, $"[[{DateTime.Now.ToString("h:mm:ss tt")}]] {message}");
+            File.AppendAllText(_logFilePath, $"[[{DateTime.Now.ToString("h:mm:ss tt")}]] {message}\n");
         }
     }
 }

--- a/SteamPrefill/Handlers/Steam/LicenseManager.cs
+++ b/SteamPrefill/Handlers/Steam/LicenseManager.cs
@@ -34,7 +34,7 @@
         /// - If a user owns an App, and the Package that grants the App ownership also grants ownership to the App's depots, then the user owns the depot.
         /// - If the user owns an App with DLC, and the App owns the depot + a Package grants ownership of the depot, then the user owns the depot.
         /// - If the user owns an App with DLC but DLC App has no depots of its own. And instead the App owns a depot with the same Id as the DLC App,
-        ///     then the user owns the depot.
+        ///     then the user owns the depot.  Example DLC AppId : 1962660 - DepotId : 1962660
         ///
         /// For official documentation on how this works, see : https://partner.steamgames.com/doc/store/application/dlc
         /// </summary>

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -114,7 +114,7 @@
                 catch (Exception e)
                 {
                     // Need to catch any exceptions that might happen during a single download, so that the other apps won't be affected
-                    _ansiConsole.MarkupLine(Red($"   Unexpected download error : {e.Message}"));
+                    _ansiConsole.LogMarkupLine(Red($"Unexpected download error : {e.Message}  Skipping app..."));
                     _ansiConsole.MarkupLine("");
                     _prefillSummaryResult.FailedApps++;
                 }


### PR DESCRIPTION
…here seems to be no performance difference between the two.  This should hopefully help with diagnosing the persistent "manifest download failed" issues by being able to more easily see what is failing.