### PR TITLE
Increasing the timeout for SteamKit2 to 60 seconds.  This will preven…

### DIFF
--- a/LancachePrefill.Common/Extensions/AnsiConsoleExtensions.cs
+++ b/LancachePrefill.Common/Extensions/AnsiConsoleExtensions.cs
@@ -1,6 +1,4 @@
-﻿using static LancachePrefill.Common.Extensions.TransferSpeedUnit;
-
-namespace LancachePrefill.Common.Extensions
+﻿namespace LancachePrefill.Common.Extensions
 {
     public static class AnsiConsoleExtensions
     {
@@ -57,31 +55,59 @@ namespace LancachePrefill.Common.Extensions
             return promptTask.WaitAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
         }
 
-        private static string FormattedTime => $"[[{DateTime.Now.ToString("h:mm:ss tt")}]]";
+        //TODO I don't particularly like this.  Refactor into something more sane
+        //TODO comment
+        public static bool WriteVerboseLogs = false;
 
+        //TODO break these timer methods out into their own extension class
+        //TODO comment
+        private static string FormattedTime => $"[[{DateTime.Now.ToString("h:mm:ss")} {DateTime.Now.ToString("tt")}]]";
+
+        //TODO comment
         public static void LogMarkup(this IAnsiConsole console, string message)
         {
             console.Markup($"{FormattedTime} {message}");
         }
 
+        //TODO comment
         public static void LogMarkupLine(this IAnsiConsole console, string message)
         {
             console.MarkupLine($"{FormattedTime} {message}");
+            FileLogger.Log(message);
         }
 
         public static void LogMarkupLine(this IAnsiConsole console, string message, Stopwatch stopwatch)
-        {
-            console.LogMarkupLine(message, stopwatch.Elapsed);
-        }
-
-        public static void LogMarkupLine(this IAnsiConsole console, string message, TimeSpan elapsed)
         {
             var messageWithTime = $"{FormattedTime} {message}";
             // Taking the difference between the original message length, and the message length with markup removed.  
             // Ensures that PadRight will align messages with markup correctly.
             var paddingDiff = messageWithTime.Length - new Markup(messageWithTime).Length;
 
-            console.MarkupLine(messageWithTime.PadRight(65 + paddingDiff) + LightYellow(elapsed.ToString(@"ss\.FFFF")));
+            var formattedElapsedTime = stopwatch.Elapsed.ToString(@"ss\.FFFF");
+            console.MarkupLine(messageWithTime.PadRight(65 + paddingDiff) + LightYellow(formattedElapsedTime));
+            FileLogger.Log($"{message} {formattedElapsedTime}");
+        }
+
+        //TODO comment
+        //TODO Replace LogMarkupLine() instances in the codebase that could use this instead.
+        public static void LogMarkupVerbose(this IAnsiConsole console, string message)
+        {
+            // Always write to the logfile
+            FileLogger.Log(message);
+
+            // Skip writing to console unless verbose logging is enabled
+            if (!WriteVerboseLogs)
+            {
+                return;
+            }
+            console.MarkupLine($"{FormattedTime} {message}");
+        }
+
+        //TODO comment
+        public static void LogMarkupError(this IAnsiConsole console, string message)
+        {
+            console.MarkupLine($"{FormattedTime} {Red(message)}");
+            FileLogger.Log(message);
         }
 
         public static Markup ToMarkup(this Object obj)

--- a/LancachePrefill.Common/FileLogger.cs
+++ b/LancachePrefill.Common/FileLogger.cs
@@ -2,12 +2,19 @@
 {
     public static class FileLogger
     {
-        private static string _logFilePath = "errorlog.txt";
+        private static string _logFilePath = "app.log";
 
         //TODO need to move this over to using a logging library, rather than doing this manually
         public static void Log(string message)
         {
-            File.AppendAllText(_logFilePath, $"[[{DateTime.Now.ToString("h:mm:ss tt")}]] {message}\n");
+            var messageNoAnsi = message.RemoveMarkup();
+            File.AppendAllText(_logFilePath, $"[{DateTime.Now.ToString("h:mm:ss tt")}] {messageNoAnsi}\n");
+        }
+
+        public static void LogException(string message, Exception e)
+        {
+            Log(message);
+            Log(e.ToString());
         }
     }
 }

--- a/SteamPrefill/Handlers/AppInfoHandler.cs
+++ b/SteamPrefill/Handlers/AppInfoHandler.cs
@@ -55,7 +55,7 @@
                 }
             });
 #if DEBUG
-            _ansiConsole.LogMarkupLine($"Loaded metadata for {Magenta(appIds.Count)} apps ", timer.Elapsed);
+            _ansiConsole.LogMarkupLine($"Loaded metadata for {Magenta(appIds.Count)} apps ", timer);
 #endif
         }
 

--- a/SteamPrefill/Handlers/Steam/CdnPool.cs
+++ b/SteamPrefill/Handlers/Steam/CdnPool.cs
@@ -87,7 +87,8 @@ namespace SteamPrefill.Handlers.Steam
 
                     // Filtering out non-cacheable HTTPs CDNs.  SteamCache type servers are Valve run.  CDN type servers appear to be ISP run.
                     AvailableServerEndpoints = AvailableServerEndpoints
-                                                .Where(e => (e.Type == "SteamCache" || e.Type == "CDN") && e.AllowedAppIds.Length == 0)
+                                                .Where(e => e.Protocol == Server.ConnectionProtocol.HTTP && e.AllowedAppIds.Length == 0
+                                                                                                         && (e.Type == "SteamCache" || e.Type == "CDN"))
                                                 .DistinctBy(e => e.Host)
                                                 .ToConcurrentStack();
                 }).WaitAsync(TimeSpan.FromSeconds(6));

--- a/SteamPrefill/Handlers/Steam/Steam3Session.cs
+++ b/SteamPrefill/Handlers/Steam/Steam3Session.cs
@@ -53,9 +53,9 @@ namespace SteamPrefill.Handlers.Steam
             _callbackManager.Subscribe<SteamApps.LicenseListCallback>(LicenseListCallback);
 
             CdnClient = new Client(_steamClient);
-            // Configuring SteamKit's HttpClient to timeout in a more reasonable time frame.
-            Client.ResponseBodyTimeout = TimeSpan.FromSeconds(5);
-            Client.RequestTimeout = TimeSpan.FromSeconds(5);
+            // Configuring SteamKit's HttpClient to timeout in a more reasonable time frame.  This is only used when downloading manifests
+            Client.ResponseBodyTimeout = AppConfig.SteamKitRequestTimeout;
+            Client.RequestTimeout = AppConfig.SteamKitRequestTimeout;
 
             _userAccountStore = UserAccountStore.LoadFromFile();
             LicenseManager = new LicenseManager(SteamAppsApi, _userAccountStore);

--- a/SteamPrefill/Program.cs
+++ b/SteamPrefill/Program.cs
@@ -1,6 +1,8 @@
 namespace SteamPrefill
 {
     /* TODO
+     * Testing - See how chunk downloads react to throttled internet bandwidth ~1mb/s.  Does it throw a lot of TimeoutException/TaskCancelledExceptions? 
+     *
      * Research -Determine if there is a way to selectively delete games from the cache, so that I don't have to nuke my whole cache to test something.
      * Testing - Should invest some time into adding unit tests
      * Cleanup Resharper code issues, and github code issues.

--- a/SteamPrefill/Settings/AppConfig.cs
+++ b/SteamPrefill/Settings/AppConfig.cs
@@ -12,16 +12,19 @@ namespace SteamPrefill.Settings
             MigrateSuccessfullyDownloadedDepots();
         }
 
-#if DEBUG
-
-        public static bool EnableSteamKitDebugLogs => false;
-        public static bool SkipDownloads { get; set; }
-
-#endif
-
         public static string SteamCdnUrl => "lancache.steamcontent.com";
 
-        public static bool VerboseLogs { get; set; }
+        //TODO comment
+        private static bool _verboseLogs;
+        public static bool VerboseLogs
+        {
+            get => _verboseLogs;
+            set
+            {
+                _verboseLogs = value;
+                AnsiConsoleExtensions.WriteVerboseLogs = value;
+            }
+        }
 
         /// <summary>
         /// Downloaded manifests, as well as other metadata, are saved into this directory to speedup future prefill runs.
@@ -41,6 +44,13 @@ namespace SteamPrefill.Settings
         /// Contains user configuration.  Should not be deleted, doing so will reset the app back to defaults.
         /// </summary>
         public static readonly string ConfigDir = Path.Combine(AppContext.BaseDirectory, "Config");
+
+        #region Timeouts
+
+        //TODO comment
+        public static TimeSpan SteamKitRequestTimeout => TimeSpan.FromSeconds(60);
+
+        #endregion
 
         #region Serialization file paths
 
@@ -62,6 +72,13 @@ namespace SteamPrefill.Settings
         public static readonly string SuccessfullyDownloadedDepotsPath = Path.Combine(ConfigDir, "successfullyDownloadedDepots.json");
 
         #endregion
+
+#if DEBUG
+
+        public static bool EnableSteamKitDebugLogs => false;
+        public static bool SkipDownloads { get; set; }
+
+#endif
 
         /// <summary>
         /// Gets the base directories for the cache folder, determined by which Operating System the app is currently running on.


### PR DESCRIPTION
…t timeouts when downloading manifests on a slow internet connection ( < 1 megabyte/second).

Adding more verbose logging that will only be shown when specifying the --verbose flag. Fixed a bug with CdnPool where it would include HTTPS CDNs