### PR TITLE
Manually excluding VTOL VR dlc depot.  It isn't possible to request a…

### DIFF
--- a/SteamPrefill/Handlers/DepotHandler.cs
+++ b/SteamPrefill/Handlers/DepotHandler.cs
@@ -65,6 +65,11 @@
 
             foreach (var depot in allDepots)
             {
+                if (ExcludedDepots.Ids.Contains(depot.DepotId))
+                {
+                    continue;
+                }
+
                 // User must have access to a depot in order to download it
                 if (!_steam3Session.LicenseManager.AccountHasDepotAccess(depot.DepotId))
                 {

--- a/SteamPrefill/Models/Enums/ExcludedDepots.cs
+++ b/SteamPrefill/Models/Enums/ExcludedDepots.cs
@@ -1,0 +1,13 @@
+﻿namespace SteamPrefill.Models.Enums
+{
+    public static class ExcludedDepots
+    {
+        public static readonly HashSet<ulong> Ids = new HashSet<ulong>
+        {
+            // VTOL VR - https://steamdb.info/depot/1770480/
+            // Manually excluding this depot as it is currently impossible to request a manifest code for it, thus it shouldn't be downloaded.
+            // I'm currently unable to determine how the real Steam client determines to skip this depot.
+            1770480
+        };
+    }
+}


### PR DESCRIPTION
… manifest code for it, as shouldn't be downloaded, however I'm unable to determine how Steam knows to skip it.