### PR TITLE
Adding a lock so that concurrent file logging won't throw an exceptio…

### DIFF
--- a/LancachePrefill.Common/FileLogger.cs
+++ b/LancachePrefill.Common/FileLogger.cs
@@ -3,12 +3,17 @@
     public static class FileLogger
     {
         private static string _logFilePath = "app.log";
+        private static object _lockObject = new object();
 
         //TODO need to move this over to using a logging library, rather than doing this manually
         public static void Log(string message)
         {
-            var messageNoAnsi = message.RemoveMarkup();
-            File.AppendAllText(_logFilePath, $"[{DateTime.Now.ToString("h:mm:ss tt")}] {messageNoAnsi}\n");
+            //TODO this isn't ideal, but this lock is here to avoid writing to the same file concurrently.  Should likely switch over to an actual logging library
+            lock (_lockObject)
+            {
+                var messageNoAnsi = message.RemoveMarkup();
+                File.AppendAllText(_logFilePath, $"[{DateTime.Now.ToString("h:mm:ss tt")}] {messageNoAnsi}\n");
+            }
         }
 
         public static void LogException(string message, Exception e)

--- a/SteamPrefill/Handlers/Steam/Steam3Session.cs
+++ b/SteamPrefill/Handlers/Steam/Steam3Session.cs
@@ -144,7 +144,8 @@ namespace SteamPrefill.Handlers.Steam
                 Password = loginKey == null ? _ansiConsole.ReadPassword() : null,
                 ShouldRememberPassword = true,
                 LoginKey = loginKey,
-                LoginID = 5995
+                //TODO randomize and save this loginId per instance.  Should prevent multiple instances of SteamPrefill from being logged out
+                LoginID = 5395
             };
             // Sentry file is required when using Steam Guard w\ email
             if (_userAccountStore.SentryData.TryGetValue(_logonDetails.Username, out var bytes))

--- a/SteamPrefill/Program.cs
+++ b/SteamPrefill/Program.cs
@@ -1,13 +1,11 @@
 namespace SteamPrefill
 {
     /* TODO
-     * Testing - See how chunk downloads react to throttled internet bandwidth ~1mb/s.  Does it throw a lot of TimeoutException/TaskCancelledExceptions? 
-     *
-     * Research -Determine if there is a way to selectively delete games from the cache, so that I don't have to nuke my whole cache to test something.
      * Testing - Should invest some time into adding unit tests
      * Cleanup Resharper code issues, and github code issues.
      * Cleanup TODOs
      * Build - Fail build on trim warnings
+     * Research - Determine if Polly could be used in this project
      */
     public static class Program
     {


### PR DESCRIPTION
…n. Speeding up manifest loading by loading cached manifests in parallel