### PR TITLE
Update Steam3Session.cs

### DIFF
--- a/SteamPrefill/Handlers/Steam/Steam3Session.cs
+++ b/SteamPrefill/Handlers/Steam/Steam3Session.cs
@@ -202,7 +202,7 @@ namespace SteamPrefill.Handlers.Steam
             {
                 _userAccountStore.SessionTokens.Remove(_logonDetails.Username);
                 _logonDetails.LoginKey = null;
-                _logonDetails.Password = _ansiConsole.ReadPasswordAsync("Steam session expired!  Password re-entry required!").GetAwaiter().GetResult();
+                _logonDetails.Password = _ansiConsole.ReadPasswordAsync("Steam session expired!  Password re-entry required! --> :").GetAwaiter().GetResult();
                 return false;
             }
 


### PR DESCRIPTION
When the Steam session expires and password re-entry is required this makes it clearer that this is in fact a prompt to input the password again at the end of the line instead of just an error message.