### PR TITLE
Adding a conditional check to see if the app is running on xterm, and…

### DIFF
--- a/SteamPrefill/Properties/launchSettings.json
+++ b/SteamPrefill/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     },
     "Prefill Selected": {
       "commandName": "Project",
-      "commandLineArgs": "prefill --force --no-download --verbose"
+      "commandLineArgs": "prefill --force --verbose"
     },
     "Benchmark - Setup Ids - Best Case Workload": {
       "commandName": "Project",


### PR DESCRIPTION
… only enabling the use of System.Console if that is the case.  Using System.Console on other terminal color modes will cause the app to be unable to be killed using ctrl+c