### PR TITLE
Adding a check to make sure that the user has previously selected app…

### DIFF
--- a/docs/RenderAnsiToSvg/functions.py
+++ b/docs/RenderAnsiToSvg/functions.py
@@ -1,5 +1,7 @@
 #TODO document
 
+# This is rendering an SVG (Scalable Vector Graphic - https://en.wikipedia.org/wiki/SVG)
+
 #region imports
 
 import re


### PR DESCRIPTION
…s when attempting to setup a benchmark with --use-selected.  A proper error message will now be displayed.