### PR TITLE
Download only as needed

### DIFF
--- a/SteamPrefill/Handlers/DownloadHandler.cs
+++ b/SteamPrefill/Handlers/DownloadHandler.cs
@@ -100,16 +100,40 @@
                     using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
                     requestMessage.Headers.Host = cdnServer.Host;
 
-                    using var cts = new CancellationTokenSource();
-                    using var response = await _client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
-                    using Stream responseStream = await response.Content.ReadAsStreamAsync(cts.Token);
-                    response.EnsureSuccessStatusCode();
+                    using var requestHead = new HttpRequestMessage(HttpMethod.Head, url);
 
-                    // Don't save the data anywhere, so we don't have to waste time writing it to disk.
-                    var buffer = new byte[4096];
-                    while (await responseStream.ReadAsync(buffer, cts.Token) != 0)
+
+                    using var cts = new CancellationTokenSource();
+
+
+                    string status = "MISS";
+                    if(AppConfig.FastCache)
                     {
+
+                        using var head = await _client.SendAsync(requestHead, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+
+                        IEnumerable<string> values;
+                        if (head.Headers.TryGetValues("X-Cache-Status", out values))
+                        {
+                            status = values.FirstOrDefault();
+                        }
+
                     }
+
+                    if (status != "HIT")
+                    {
+                        using var response = await _client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+                        using Stream responseStream = await response.Content.ReadAsStreamAsync(cts.Token);
+                        response.EnsureSuccessStatusCode();
+
+                        // Don't save the data anywhere, so we don't have to waste time writing it to disk.
+                        var buffer = new byte[4096];
+                        while (await responseStream.ReadAsync(buffer, cts.Token) != 0)
+                        {
+                        }
+                    }
+
                 }
                 catch (Exception e)
                 {

--- a/SteamPrefill/Program.cs
+++ b/SteamPrefill/Program.cs
@@ -90,10 +90,10 @@ namespace SteamPrefill
                 args.Remove("--no-cache");
             }
 
-            // Skips already downloaded segments using a headers check
+            // Skips already downloaded chunks using a headers check
             if (args.Any(e => e.Contains("--fast-cache")) || args.Any(e => e.Contains("--fastcache")) || args.Any(e => e.Contains("--skip-cached")) || args.Any(e => e.Contains("--skip-cached")))
             {
-                AnsiConsole.Console.LogMarkupLine($"Using {Red("--fastcache")} flag. Will skip transmitting segments the lancache already has. {Red("Do not use this with a benchmark. Your result will be inaccurate.")}");
+                AnsiConsole.Console.LogMarkupLine($"Using {Red("--fastcache")} flag. Will skip transmitting chunks the lancache already has. {Red("Do not use this flag with a benchmark. Your result will be inaccurate.")}");
                 AppConfig.FastCache = true;
                 args.Remove("--fast-cache");
                 args.Remove("--fastcache");

--- a/SteamPrefill/Program.cs
+++ b/SteamPrefill/Program.cs
@@ -90,6 +90,17 @@ namespace SteamPrefill
                 args.Remove("--no-cache");
             }
 
+            // Skips already downloaded segments using a headers check
+            if (args.Any(e => e.Contains("--fast-cache")) || args.Any(e => e.Contains("--fastcache")) || args.Any(e => e.Contains("--skip-cached")) || args.Any(e => e.Contains("--skip-cached")))
+            {
+                AnsiConsole.Console.LogMarkupLine($"Using {Red("--fastcache")} flag. Will skip transmitting segments the lancache already has. {Red("Do not use this with a benchmark. Your result will be inaccurate.")}");
+                AppConfig.FastCache = true;
+                args.Remove("--fast-cache");
+                args.Remove("--fastcache");
+                args.Remove("--skip-cached");
+                args.Remove("--skipcached");
+            }
+
             // Adding some formatting to logging to make it more readable + clear that these flags are enabled
             if (AppConfig.DebugLogs || AppConfig.SkipDownloads || AppConfig.NoLocalCache)
             {

--- a/SteamPrefill/Settings/AppConfig.cs
+++ b/SteamPrefill/Settings/AppConfig.cs
@@ -82,6 +82,11 @@ namespace SteamPrefill.Settings
         /// </summary>
         public static bool SkipDownloads { get; set; }
 
+        /// <summary>
+        /// Will skip any chunks that have already been downloaded. Using for quickly resuming downloads that may have been interrupted, or to only download updated chunks when a game update is released.
+        /// </summary>
+        public static bool FastCache {get; set;}
+
         private static bool _debugLogs;
         public static bool DebugLogs
         {


### PR DESCRIPTION
This PR adds a small change that makes prefill do a HEAD request, and check if `X-Cache-Status` is set to `HIT`. If it is, then it can safely skip and move onto the next chunk. Avoids unnecessary downloads from the cache server.