### PR TITLE
When a request fails it will be retried with the nocache url paramete…

### DIFF
--- a/SteamPrefill/Models/DownloadArguments.cs
+++ b/SteamPrefill/Models/DownloadArguments.cs
@@ -7,6 +7,7 @@
         /// </summary>
         public bool Force { get; init; }
 
+        //TODO this should probably just use the global static one from AppConfig
         /// <summary>
         /// When set to true, will avoid saving as much data to disk as possible.  Currently only saves manifests to disk.
         /// </summary>


### PR DESCRIPTION
…r, which will make the cache redownload a request and overwrite the data currently saved on disk.