### PR TITLE
Fixing an issue created by a previous change for logging in with pass…

### DIFF
--- a/SteamPrefill/Extensions/MiscExtensions.cs
+++ b/SteamPrefill/Extensions/MiscExtensions.cs
@@ -46,7 +46,12 @@
                                       .Secret());
 
                 // For whatever reason Steam allows you to enter as long of a password as you'd like, and silently truncates anything after 64 characters
-                return password.Substring(0, 64);
+                if (password.Length > 64)
+                {
+                    return password.Substring(0, 64);
+                }
+
+                return password;
             });
             return await promptTask.WaitAsync(TimeSpan.FromSeconds(30));
         }


### PR DESCRIPTION
…words longer than 64 characters, which broke logging in with a password shorter than 64 characters.