### PR TITLE
Add options to select-apps command

### DIFF
--- a/SteamPrefill/CliCommands/SelectAppsCommand.cs
+++ b/SteamPrefill/CliCommands/SelectAppsCommand.cs
@@ -12,6 +12,17 @@ namespace SteamPrefill.CliCommands
             Converter = typeof(NullableBoolConverter))]
         public bool? NoAnsiEscapeSequences { get; init; }
 
+        [CommandOption("all", 'a',
+            Description = "Select all owned applications without opening the GUI.",
+            Converter = typeof(NullableBoolConverter))]
+        public bool? SelectAll { get; init; }
+
+        [CommandOption("run-prefill", 'p',
+            Description = "Automatically run prefill after selection (bypasses prompt)." +
+                          "Defaults to true, but can be set to false to bypass prompt without running prefill.",
+            Converter = typeof(NullableBoolConverter))]
+        public bool? RunPrefill { get; init; }
+
         public async ValueTask ExecuteAsync(IConsole console)
         {
             var ansiConsole = console.CreateAnsiConsole();
@@ -24,39 +35,58 @@ namespace SteamPrefill.CliCommands
                 await steamManager.InitializeAsync();
                 var tuiAppModels = await BuildTuiAppModelsAsync(steamManager);
 
-                if (System.OperatingSystem.IsLinux())
+                if (!(SelectAll ?? false))
                 {
-                    // This is required to be enabled otherwise some Linux distros/shells won't display color correctly.
-                    Application.UseSystemConsole = true;
+                    if (System.OperatingSystem.IsLinux())
+                    {
+                        // This is required to be enabled otherwise some Linux distros/shells won't display color correctly.
+                        Application.UseSystemConsole = true;
+                    }
+                    if (System.OperatingSystem.IsWindows())
+                    {
+                        // Must be set to false on Windows otherwise navigation will not work in Windows Terminal
+                        Application.UseSystemConsole = false;
+                    }
+
+                    Application.Init();
+                    using var tui2 = new SelectAppsTui(tuiAppModels);
+                    Key userKeyPress = tui2.Run();
+
+                    // There is an issue with Terminal.Gui where this property is set to 'true' when the TUI is initialized, but forgets to reset it back to 'false' when the TUI closes.
+                    // This causes an issue where the prefill run is not able to be cancelled with ctrl+c, but only on Linux systems.
+                    Console.TreatControlCAsInput = false;
+
+
+                    // Will only allow for prefill if the user has saved changes.  Escape simply exists
+                    if (userKeyPress != Key.Enter)
+                    {
+                        return;
+                    }
+                    steamManager.SetAppsAsSelected(tuiAppModels);
+
+                    // This escape sequence is required when running on linux, otherwise will not be able to use the Spectre selection prompt
+                    // See : https://github.com/gui-cs/Terminal.Gui/issues/418
+                    await console.Output.WriteAsync("\x1b[?1h");
+                    await console.Output.FlushAsync();
                 }
-                if (System.OperatingSystem.IsWindows())
+                else
                 {
-                    // Must be set to false on Windows otherwise navigation will not work in Windows Terminal
-                    Application.UseSystemConsole = false;
+                    var newApps = SelectAllApps(tuiAppModels);
+                    ansiConsole.WriteLine();
+                    ansiConsole.LogMarkupLine($"{newApps.Count} new apps selected:");
+
+                    if (newApps.Any())
+                    {
+                        foreach (var newApp in newApps)
+                        {
+                            ansiConsole.LogMarkupLine(newApp);
+                        }
+
+                        steamManager.SetAppsAsSelected(tuiAppModels);
+                    }
                 }
 
-                Application.Init();
-                using var tui2 = new SelectAppsTui(tuiAppModels);
-                Key userKeyPress = tui2.Run();
-
-                // There is an issue with Terminal.Gui where this property is set to 'true' when the TUI is initialized, but forgets to reset it back to 'false' when the TUI closes.
-                // This causes an issue where the prefill run is not able to be cancelled with ctrl+c, but only on Linux systems.
-                Console.TreatControlCAsInput = false;
-
-
-                // Will only allow for prefill if the user has saved changes.  Escape simply exists
-                if (userKeyPress != Key.Enter)
-                {
-                    return;
-                }
-                steamManager.SetAppsAsSelected(tuiAppModels);
-
-                // This escape sequence is required when running on linux, otherwise will not be able to use the Spectre selection prompt
-                // See : https://github.com/gui-cs/Terminal.Gui/issues/418
-                await console.Output.WriteAsync("\x1b[?1h");
-                await console.Output.FlushAsync();
-
-                var runPrefill = ansiConsole.Prompt(new SelectionPrompt<bool>()
+                var runPrefill = RunPrefill ?? ansiConsole.Prompt(new SelectionPrompt<bool>()
                                                     .Title(LightYellow("Run prefill now?"))
                                                     .AddChoices(true, false)
                                                     .UseConverter(e => e == false ? "No" : "Yes"));
@@ -93,6 +123,21 @@ namespace SteamPrefill.CliCommands
             }
 
             return tuiAppModels;
+        }
+
+        private List<string> SelectAllApps(List<TuiAppInfo> tuiAppModels)
+        {
+            var newApps = new List<string>();
+
+            foreach (var appInfo in tuiAppModels) 
+            { 
+                if (!appInfo.IsSelected)
+                {
+                    newApps.Add($"{appInfo.Title} ({appInfo.AppId})");
+                    appInfo.IsSelected = true;
+                }
+            }
+            return newApps;
         }
     }
 }


### PR DESCRIPTION
Added options to select all games without entering gui and to run the prefill after selection (bypassing the prompt). The intention is to allow the prefill to be run on a schedule while automatically adding new games to the list. 

This is my first attempt at contributing to a project, so sorry if I did it wrong.