### PR TITLE
Add a force-localhost flag to prefill command

### DIFF
--- a/SteamPrefill/CliCommands/Benchmark/BenchmarkRunCommand.cs
+++ b/SteamPrefill/CliCommands/Benchmark/BenchmarkRunCommand.cs
@@ -23,6 +23,11 @@ namespace SteamPrefill.CliCommands.Benchmark
             Converter = typeof(NullableBoolConverter))]
         public bool? NoAnsiEscapeSequences { get; init; }
 
+        [CommandOption("force-localhost",
+            Description = "Force the application to use the localhost IP (127.0.0.1) instead of the DNS IP (usefull in case the application is on the same lancache server)",
+            Converter = typeof(NullableBoolConverter))]
+        public bool? ForceLocalhost { get; init; }
+
         private IAnsiConsole _ansiConsole;
 
         private CdnPool _cdnPool;
@@ -93,7 +98,7 @@ namespace SteamPrefill.CliCommands.Benchmark
                 _allRequests.Shuffle();
             });
 
-            _downloadHandler = new DownloadHandler(_ansiConsole, _cdnPool);
+            _downloadHandler = new DownloadHandler(_ansiConsole, _cdnPool, ForceLocalhost ?? false);
             await _downloadHandler.InitializeAsync();
 
             _ansiConsole.LogMarkupLine("Completed initialization", initTimer);

--- a/SteamPrefill/CliCommands/PrefillCommand.cs
+++ b/SteamPrefill/CliCommands/PrefillCommand.cs
@@ -50,6 +50,11 @@ namespace SteamPrefill.CliCommands
             Converter = typeof(NullableBoolConverter))]
         public bool? NoAnsiEscapeSequences { get; init; }
 
+        [CommandOption("force-localhost",
+            Description = "Force the application to use the localhost IP (127.0.0.1) instead of the DNS IP (usefull in case the application is on the same lancache server)",
+            Converter = typeof(NullableBoolConverter))]
+        public bool? ForceLocalhost { get; init; }
+
         private IAnsiConsole _ansiConsole;
         private int? _prefillPopularGames;
 
@@ -65,6 +70,7 @@ namespace SteamPrefill.CliCommands
             {
                 Force = Force ?? false,
                 TransferSpeedUnit = TransferSpeedUnit,
+                ForceLocalhost = ForceLocalhost ?? false,
                 OperatingSystems = OperatingSystems.ToList()
             };
 

--- a/SteamPrefill/Models/DownloadArguments.cs
+++ b/SteamPrefill/Models/DownloadArguments.cs
@@ -42,5 +42,10 @@
 
         public Architecture Architecture { get; init; } = Architecture.x64;
         public Language Language { get; init; } = Language.English;
+
+        /// <summary>
+        /// When set to true, force the usage of localhost IP instead of resolving lancache IP
+        /// </summary>
+        public bool ForceLocalhost { get; init; }
     }
 }

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -22,7 +22,7 @@
             _steam3 = new Steam3Session(_ansiConsole);
             _cdnPool = new CdnPool(_ansiConsole, _steam3);
             _appInfoHandler = new AppInfoHandler(_ansiConsole, _steam3, _steam3.LicenseManager);
-            _downloadHandler = new DownloadHandler(_ansiConsole, _cdnPool);
+            _downloadHandler = new DownloadHandler(_ansiConsole, _cdnPool, downloadArgs.ForceLocalhost);
             _depotHandler = new DepotHandler(_ansiConsole, _steam3, _appInfoHandler, _cdnPool);
         }
 

--- a/docs/mkdocs/detailed-command-usage/Prefill.md
+++ b/docs/mkdocs/detailed-command-usage/Prefill.md
@@ -63,3 +63,4 @@ It is possible to combine multiple flags together in a single command, rather th
 | --verbose   |     |                       |             | Produces more detailed log output.  By default, games that are already up to date will not be displayed at all.  Specifying this option will make it so that all games, even ones up to date, will be logged.  |
 | --unit      |     | bits, bytes           | **bits**    | Specifies which unit to use to display download speed.   |
 | --no-ansi   |     |                       |             | Application output will be in plain text, rather than using the visually appealing colors and progress bars.  Should only be used if terminal does not support Ansi Escape sequences, or when redirecting output to a file. |
+| --force-localhost |     |                       |             | Force the application to use the localhost IP (127.0.0.1) instead of the DNS IP (usefull in case the application is on the same lancache server). |


### PR DESCRIPTION
This PR introduces a new ```--force-localhost``` flag to the ```prefill``` command.

**Initial problem :** 
I did create a lancache server on one of my proxmox lxc machine and put SteamPrefill/EpicPrefill on the same machine. Using SteamPrefill and EpicPrefill, i do not wish to modify the host file of the machine to enter all the DNS records and point them to localhost to prevent an outbound then back connexion to access the internal Lancache.

**Purpose :** 
Force the prefill command to use the "localhost" IP for it's downloads rather than resolving the IP of the lancache server through the dns (localhost resolution comes late on the multiple try and if the dns is working it'll always give the public address of the server). Usefull when SteamPrefill is on the same server as Lancache.

**Implementation:**
- Adds the ```--force-localhost``` flag to the ```prefill``` command.
- Updated the documenation
- Tested successfully on my deployed stack

**Future:**
Implement the same feature on the rest of the ```*Prefill``` family

[I apologize for my grammar or vocabulary mistakes. English is not my native language]