### PR TITLE
fix: failover to another CDN when a server returns a 403 for a depot

### DIFF
--- a/SteamPrefill/Handlers/DownloadHandler.cs
+++ b/SteamPrefill/Handlers/DownloadHandler.cs
@@ -226,6 +226,10 @@
                         var url = $"http://{_lancacheAddress}/depot/{probe.DepotId}/chunk/{probe.ChunkId}?nocache=1";
                         using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
                         requestMessage.Headers.Host = server.Host;
+                        // Only the response status matters for the probe, so request a single byte rather than transferring
+                        // the full ~1MB chunk over a potentially slow connection.  A serving CDN returns 200/206, one that
+                        // doesn't cache this depot still returns 403.
+                        requestMessage.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(0, 0);
 
                         using var cts = new CancellationTokenSource();
                         using var response = await _client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);

--- a/SteamPrefill/Handlers/DownloadHandler.cs
+++ b/SteamPrefill/Handlers/DownloadHandler.cs
@@ -41,16 +41,25 @@
 
             int retryCount = 0;
             var failedRequests = new ConcurrentBag<QueuedRequest>();
+            // Tracks CDN servers that have returned a 403 for a given depot.  A 403 means that CDN does not cache that
+            // depot, so we avoid re-using it for that depot (while still allowing it to serve other depots).  Persisted
+            // across retries so blacklisted servers stay excluded.  depotId -> set of blacklisted server hosts.
+            var depotServerBlacklist = new ConcurrentDictionary<uint, ConcurrentDictionary<string, byte>>();
+
+            // Not every CDN caches every depot, so probe once per depot up front to find (and report) a server that
+            // actually serves it.  This avoids a storm of failed requests being discovered during the bulk download.
+            var depotServers = await ProbeDepotServersAsync(queuedRequests, depotServerBlacklist);
+
             await _ansiConsole.CreateSpectreProgress(downloadArgs.TransferSpeedUnit).StartAsync(async ctx =>
             {
                 // Run the initial download
-                failedRequests = await AttemptDownloadAsync(ctx, "Downloading..", queuedRequests, downloadArgs);
+                failedRequests = await AttemptDownloadAsync(ctx, "Downloading..", queuedRequests, downloadArgs, depotServers: depotServers, depotServerBlacklist: depotServerBlacklist);
 
                 // Handle any failed requests
                 while (failedRequests.Any() && retryCount < 2)
                 {
                     retryCount++;
-                    failedRequests = await AttemptDownloadAsync(ctx, $"Retrying  {retryCount}..", failedRequests.ToList(), downloadArgs, forceRecache: true);
+                    failedRequests = await AttemptDownloadAsync(ctx, $"Retrying  {retryCount}..", failedRequests.ToList(), downloadArgs, forceRecache: true, depotServers: depotServers, depotServerBlacklist: depotServerBlacklist);
                 }
             });
 
@@ -81,35 +90,100 @@
         /// <param name="forceRecache">When specified, will cause the cache to delete the existing cached data for a request, and re-download it again.</param>
         /// <returns>A list of failed requests</returns>
         public async Task<ConcurrentBag<QueuedRequest>> AttemptDownloadAsync(ProgressContext ctx, string taskTitle, List<QueuedRequest> requestsToDownload,
-                                                                                DownloadArguments downloadArgs, bool forceRecache = false)
+                                                                                DownloadArguments downloadArgs, bool forceRecache = false,
+                                                                                ConcurrentDictionary<uint, Server> depotServers = null,
+                                                                                ConcurrentDictionary<uint, ConcurrentDictionary<string, byte>> depotServerBlacklist = null)
         {
+            // depotServers is pre-seeded by the probe phase, but defaulted here so the benchmark commands can call this directly.
+            depotServers ??= new ConcurrentDictionary<uint, Server>();
+            depotServerBlacklist ??= new ConcurrentDictionary<uint, ConcurrentDictionary<string, byte>>();
+
             double requestTotalSize = requestsToDownload.Sum(e => e.CompressedLength);
             var progressTask = ctx.AddTask(taskTitle, new ProgressTaskSettings { MaxValue = requestTotalSize });
 
             var failedRequests = new ConcurrentBag<QueuedRequest>();
 
-            var cdnServer = _cdnPool.TakeConnection();
+            // A shared snapshot of all available servers.  Rather than using a single server for the entire batch, each
+            // depot is assigned a server independently, so that a 403 from one CDN (meaning that CDN doesn't cache that
+            // particular depot) can fail over to a different server for that depot only.
+            var availableServers = _cdnPool.GetServersByLoad();
+            var assignmentLock = new object();
+
+            bool IsBlacklisted(uint depotId, string host)
+                => depotServerBlacklist.TryGetValue(depotId, out var hosts) && hosts.ContainsKey(host);
+
+            // Returns the server currently assigned to a depot, picking a new one if the depot has no assignment yet or
+            // its current server has been blacklisted.  Returns null when every available server has 403'd for the depot.
+            Server GetServerForDepot(uint depotId)
+            {
+                if (depotServers.TryGetValue(depotId, out var assigned) && !IsBlacklisted(depotId, assigned.Host))
+                {
+                    return assigned;
+                }
+
+                lock (assignmentLock)
+                {
+                    // Re-check inside the lock, another thread may have already rotated to a valid server.
+                    if (depotServers.TryGetValue(depotId, out var current) && !IsBlacklisted(depotId, current.Host))
+                    {
+                        return current;
+                    }
+
+                    var next = availableServers.FirstOrDefault(server => !IsBlacklisted(depotId, server.Host));
+                    if (next != null)
+                    {
+                        depotServers[depotId] = next;
+                    }
+                    return next;
+                }
+            }
+
             await Parallel.ForEachAsync(requestsToDownload, new ParallelOptions { MaxDegreeOfParallelism = downloadArgs.MaxConcurrentRequests }, body: async (request, _) =>
             {
                 try
                 {
-                    var url = $"http://{_lancacheAddress}/depot/{request.DepotId}/chunk/{request.ChunkId}";
-                    if (forceRecache)
+                    // Loop to allow failing over to a different server when a CDN returns a 403 for this depot.
+                    while (true)
                     {
-                        url += "?nocache=1";
-                    }
-                    using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-                    requestMessage.Headers.Host = cdnServer.Host;
+                        var cdnServer = GetServerForDepot(request.DepotId);
+                        if (cdnServer == null)
+                        {
+                            throw new CdnExhaustionException($"All available CDN servers returned a 403 for depot {request.DepotId}.  This depot may not be cached by any available CDN.");
+                        }
 
-                    using var cts = new CancellationTokenSource();
-                    using var response = await _client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
-                    using Stream responseStream = await response.Content.ReadAsStreamAsync(cts.Token);
-                    response.EnsureSuccessStatusCode();
+                        try
+                        {
+                            var url = $"http://{_lancacheAddress}/depot/{request.DepotId}/chunk/{request.ChunkId}";
+                            if (forceRecache)
+                            {
+                                url += "?nocache=1";
+                            }
+                            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+                            requestMessage.Headers.Host = cdnServer.Host;
 
-                    // Don't save the data anywhere, so we don't have to waste time writing it to disk.
-                    var buffer = new byte[4096];
-                    while (await responseStream.ReadAsync(buffer, cts.Token) != 0)
-                    {
+                            using var cts = new CancellationTokenSource();
+                            using var response = await _client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+                            using Stream responseStream = await response.Content.ReadAsStreamAsync(cts.Token);
+                            response.EnsureSuccessStatusCode();
+
+                            // Don't save the data anywhere, so we don't have to waste time writing it to disk.
+                            var buffer = new byte[4096];
+                            while (await responseStream.ReadAsync(buffer, cts.Token) != 0)
+                            {
+                            }
+                            break;
+                        }
+                        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            // A 403 means this CDN doesn't cache this depot.  Blacklist it for this depot only, then loop
+                            // to fail over to a different server.  The server stays available for other depots.
+                            // TryAdd is used so we only log the failover once per (depot, server), instead of once per chunk.
+                            var blacklistedHosts = depotServerBlacklist.GetOrAdd(request.DepotId, _ => new ConcurrentDictionary<string, byte>());
+                            if (blacklistedHosts.TryAdd(cdnServer.Host, 0))
+                            {
+                                _ansiConsole.LogMarkupVerbose($"CDN {Cyan(cdnServer.Host)} returned a {LightYellow("403")} for depot {LightYellow(request.DepotId)}, failing over to another server");
+                            }
+                        }
                     }
                 }
                 catch (Exception e)
@@ -120,16 +194,67 @@
                 progressTask.Increment(request.CompressedLength);
             });
 
-            //TODO In the scenario where a user still had all requests fail, potentially display a warning that there is an underlying issue
-            // Only return the connections for reuse if there were no errors
-            if (failedRequests.IsEmpty)
-            {
-                _cdnPool.ReturnConnection(cdnServer);
-            }
-
             // Making sure the progress bar is always set to its max value, in-case some unexpected error leaves the progress bar showing as unfinished
             progressTask.Increment(progressTask.MaxValue);
             return failedRequests;
+        }
+
+        /// <summary>
+        /// Probes each depot against the available CDN servers to find one that actually serves it.  Some CDNs don't
+        /// cache every depot and will return a 403, so determining (and reporting) a working server up front avoids
+        /// discovering that through a storm of failed requests during the bulk download.
+        /// </summary>
+        /// <returns>A map of depotId to the server that will be used to download it.  A depot will be absent if no server served it.</returns>
+        private async Task<ConcurrentDictionary<uint, Server>> ProbeDepotServersAsync(List<QueuedRequest> requestsToDownload,
+                                                                                        ConcurrentDictionary<uint, ConcurrentDictionary<string, byte>> depotServerBlacklist)
+        {
+            var availableServers = _cdnPool.GetServersByLoad();
+            var depotServers = new ConcurrentDictionary<uint, Server>();
+
+            // A single representative chunk per depot is enough to tell whether a server serves that depot.
+            var probeRequests = requestsToDownload.GroupBy(e => e.DepotId).Select(e => e.First()).ToList();
+
+            await Parallel.ForEachAsync(probeRequests, async (probe, _) =>
+            {
+                foreach (var server in availableServers)
+                {
+                    try
+                    {
+                        // nocache=1 forces the Lancache to consult the upstream CDN instead of serving a previously cached
+                        // chunk.  Without it, an already-cached probe chunk would return 200 and mask a CDN that actually
+                        // 403s this depot upstream, causing those 403s to surface later during the bulk download instead.
+                        var url = $"http://{_lancacheAddress}/depot/{probe.DepotId}/chunk/{probe.ChunkId}?nocache=1";
+                        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+                        requestMessage.Headers.Host = server.Host;
+
+                        using var cts = new CancellationTokenSource();
+                        using var response = await _client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+                        if (response.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            // This CDN doesn't cache this depot.  Blacklist it so the download phase skips it too.
+                            depotServerBlacklist.GetOrAdd(probe.DepotId, _ => new ConcurrentDictionary<string, byte>()).TryAdd(server.Host, 0);
+                            continue;
+                        }
+                        response.EnsureSuccessStatusCode();
+
+                        depotServers[probe.DepotId] = server;
+                        _ansiConsole.LogMarkupLine($"Depot {Cyan(probe.DepotId)} will download from CDN {LightYellow(server.Host)}");
+                        return;
+                    }
+                    catch (Exception e)
+                    {
+                        // A transient (non-403) error doesn't mean the server can't serve this depot, so don't blacklist it.
+                        // Just move on to the next candidate - the download phase can still fail over to it if needed.
+                        FileLogger.LogExceptionNoStackTrace($"Probe for depot {probe.DepotId} on {server.Host} failed", e);
+                    }
+                }
+
+                // No server served this depot during probing.  The download phase will still attempt its own failover,
+                // so leave the depot unseeded rather than failing outright here.
+                _ansiConsole.LogMarkupVerbose($"No CDN server served depot {LightYellow(probe.DepotId)} during probing");
+            });
+
+            return depotServers;
         }
 
         public void Dispose()

--- a/SteamPrefill/Handlers/ManifestHandler.cs
+++ b/SteamPrefill/Handlers/ManifestHandler.cs
@@ -102,11 +102,10 @@
                 return Manifest.LoadFromFile(depot.ManifestFileName);
             }
 
-            _ansiConsole.LogMarkupVerbose($"Downloading manifest {LightYellow(depot.ManifestId)} for depot {Cyan(depot.DepotId)}");
-
             ManifestRequestCode manifestRequestCode = await GetManifestRequestCodeAsync(depot);
 
             Server server = _cdnPool.TakeConnection();
+            _ansiConsole.LogMarkupVerbose($"Manifest {LightYellow(depot.ManifestId)} for depot {Cyan(depot.DepotId)} will download from CDN {LightYellow(server.Host)}");
             DepotManifest manifest = await _steam3Session.CdnClient.DownloadManifestAsync(depot.DepotId, depot.ManifestId.Value, manifestRequestCode.Code, server);
             if (manifest == null)
             {

--- a/SteamPrefill/Handlers/Steam/CdnPool.cs
+++ b/SteamPrefill/Handlers/Steam/CdnPool.cs
@@ -116,7 +116,6 @@ namespace SteamPrefill.Handlers.Steam
             }
 
             AvailableServerEndpoints.TryPop(out var server);
-            _ansiConsole.LogMarkupVerbose($"Using CDN {Cyan(server.Host)}");
             return server;
         }
 
@@ -128,6 +127,16 @@ namespace SteamPrefill.Handlers.Steam
         public void ReturnConnection(Server server)
         {
             AvailableServerEndpoints.Push(server);
+        }
+
+        /// <summary>
+        /// Returns a snapshot of all currently available servers, ordered by load.
+        /// Unlike <see cref="TakeConnection"/>, the servers are not removed from the pool, so that they can be shared
+        /// across multiple concurrent depot downloads and used as failover targets.
+        /// </summary>
+        public List<Server> GetServersByLoad()
+        {
+            return AvailableServerEndpoints.OrderByDescending(e => e.Load).ToList();
         }
     }
 }

--- a/SteamPrefill/Handlers/Steam/CdnPool.cs
+++ b/SteamPrefill/Handlers/Steam/CdnPool.cs
@@ -130,13 +130,15 @@ namespace SteamPrefill.Handlers.Steam
         }
 
         /// <summary>
-        /// Returns a snapshot of all currently available servers, ordered by load.
+        /// Returns a snapshot of all currently available servers, ordered by load (lowest first).
         /// Unlike <see cref="TakeConnection"/>, the servers are not removed from the pool, so that they can be shared
         /// across multiple concurrent depot downloads and used as failover targets.
+        /// Lowest-load-first matches the order <see cref="TakeConnection"/> pops servers, so probing and downloading
+        /// prefer the fastest servers ("CDN" type servers have a load of 0) before falling back to busier ones.
         /// </summary>
         public List<Server> GetServersByLoad()
         {
-            return AvailableServerEndpoints.OrderByDescending(e => e.Load).ToList();
+            return AvailableServerEndpoints.OrderBy(e => e.Load).ToList();
         }
     }
 }


### PR DESCRIPTION
### Problem

When prefilling, a single upstream CDN server was selected and used as the `Host` header for every chunk of every depot in an app. Some CDNs returned by Steam (particularly ISP-run `CDN` type servers) do not cache every depot and respond with a `403` for chunks they do not serve. There was no failover: a 403 simply failed the chunk, and the same server was retried for the whole batch, so a depot that the chosen CDN did not serve could fail repeatedly.

### Change

- **Per-depot 403 failover.** A 403 now blacklists the offending server for that depot only, and the chunk fails over to a different server. The server stays available for other depots it does serve. The blacklist persists across the existing retry passes.
- **Up-front probe.** Before the bulk download, each depot is probed against the available CDNs to find one that actually serves it, and that server is reported in the log. The probe uses `?nocache=1` so it reflects true upstream availability rather than being masked by a chunk already cached on the Lancache.
- **Shared, non-destructive server pool for chunk downloads.** Chunk downloads now read a load-ordered snapshot of available servers (`CdnPool.GetServersByLoad()`) instead of exclusively checking out a single server, since a 403 is depot-specific and should not remove a server from circulation globally. The existing `TakeConnection`/`ReturnConnection` checkout path is unchanged and still used for manifest downloads.
- **Clearer logging.**
  - New per-depot line: `Depot <id> will download from CDN <host>`.
  - The generic `Using CDN <host>` line was moved out of `CdnPool.TakeConnection()` into `ManifestHandler` and reworded to `Manifest <id> for depot <id> will download from CDN <host>`, so the manifest server is no longer mistaken for the data-download CDN.
  - 403 failovers during the bulk download are logged once per (depot, server) instead of once per chunk, eliminating the previous log spam.

### Scope / non-goals

- Only `403` responses trigger per-depot failover. Other (transient) errors keep the existing behaviour: the chunk is retried by the existing batch-level retry loop. This was a deliberate decision to keep the change targeted.
- The benchmark commands (`BenchmarkRunCommand`) are unaffected: the new `AttemptDownloadAsync` parameters are optional.

### Files

- `SteamPrefill/Handlers/DownloadHandler.cs` — probe phase, per-depot server assignment, 403 failover, deduped logging.
- `SteamPrefill/Handlers/Steam/CdnPool.cs` — added `GetServersByLoad()`; removed the misleading `Using CDN` log line.
- `SteamPrefill/Handlers/ManifestHandler.cs` — reworded manifest CDN log line to include manifest/depot/server.

### Testing

Verified manually against a live Lancache with multiple apps (Dead by Daylight, Icarus, Left 4 Dead 2, New World), including depots that several CDNs 403:

- Each depot now reports the CDN it will download from.
- 403 storms during the bulk download are gone; the probe resolves a working server up front.
- Downloads complete for depots that previously triggered repeated 403s.

Fixes #403
