### PR TITLE
Fixes an error being thrown due to an unowned app not having a purcha…

### DIFF
--- a/SteamPrefill/Handlers/AppInfoHandler.cs
+++ b/SteamPrefill/Handlers/AppInfoHandler.cs
@@ -54,7 +54,6 @@
             var initialAppIdLoadTimer = Stopwatch.StartNew();
 
             var filteredAppIds = appIds.Where(e => !LoadedAppInfos.ContainsKey(e))
-                                                .Where(e => _licenseManager.AccountHasAppAccess(e))
                                                 .Distinct()
                                                 .ToList();
 

--- a/SteamPrefill/Handlers/Steam/LicenseManager.cs
+++ b/SteamPrefill/Handlers/Steam/LicenseManager.cs
@@ -108,9 +108,15 @@
                                          .ToList();
         }
 
-        public DateTime GetPurchaseDateForApp(uint appId)
+        public DateTime? GetPurchaseDateForApp(uint appId)
         {
-            return _appPurchaseTimeLookup[appId];
+            if (_userLicenses.OwnedAppIds.Contains(appId))
+            {
+                return _appPurchaseTimeLookup[appId];
+            }
+
+            // We don't own the app, return null
+            return null;
         }
     }
 

--- a/SteamPrefill/Models/AppInfo.cs
+++ b/SteamPrefill/Models/AppInfo.cs
@@ -65,7 +65,7 @@
 
         public List<Category> Categories { get; init; }
 
-        public AppInfo(Steam3Session steamSession, uint appId, KeyValue rootKeyValue, DateTime purchaseDate)
+        public AppInfo(Steam3Session steamSession, uint appId, KeyValue rootKeyValue, DateTime? purchaseDate)
         {
             AppId = appId;
             Name = rootKeyValue["common"]["name"].Value.EscapeMarkup();

--- a/SteamPrefill/Properties/launchSettings.json
+++ b/SteamPrefill/Properties/launchSettings.json
@@ -20,6 +20,10 @@
       "commandName": "Project",
       "commandLineArgs": "prefill --force --verbose"
     },
+    "Prefill Top": {
+      "commandName": "Project",
+      "commandLineArgs": "prefill --top --force --no-download --verbose"
+    },
     "Select Apps": {
       "commandName": "Project",
       "commandLineArgs": "select-apps"

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -104,7 +104,7 @@
                 {
                     var purchaseDate = _steam3.LicenseManager.GetPurchaseDateForApp(appId);
                     var appInfo = await _appInfoHandler.GetAppInfoAsync(appId);
-                    _ansiConsole.LogMarkupVerbose($"  {Green(appInfo.Name).PadRight(35)} - Purchased: {LightYellow(purchaseDate.ToLocalTime().ToString("yyyy-MM-dd"))}");
+                    _ansiConsole.LogMarkupVerbose($"  {Green(appInfo.Name).PadRight(50)} Purchased: {LightYellow(purchaseDate.Value.ToLocalTime().ToString("yyyy-MM-dd"))}");
                 }
             }
 


### PR DESCRIPTION
…se data.  Fixed an issue where --top would be very slow to load due to bulk metadata loading excluding unowned apps.