### PR TITLE
Changing the dockerfile back to putting the built executable into its…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ ENV \
         LC_ALL=en_US.UTF-8 \
         TERM=xterm-256color
 
-WORKDIR /usr/bin
-COPY  /publish/SteamPrefill /
-RUN chmod +x /SteamPrefill
+COPY  /publish/SteamPrefill /app/SteamPrefill
+RUN chmod +x /app/SteamPrefill
 
-ENTRYPOINT [ "/SteamPrefill" ]
+ENTRYPOINT [ "/app/SteamPrefill" ]


### PR DESCRIPTION
… own /app directory, rather than into usr/bin.  For whatever reason when the arm executable is located in /usr/bin it will not work, but putting it anywhere else will.