### PR TITLE
fix: Show cursor after CTRL+C interrupt

### DIFF
--- a/SteamPrefill/Program.cs
+++ b/SteamPrefill/Program.cs
@@ -4,6 +4,11 @@ namespace SteamPrefill
     {
         public static async Task<int> Main()
         {
+            Console.CancelKeyPress += (_, _) => {
+                AnsiConsole.Write("\x1b[?25h\n");
+                Console.Out.Flush();
+            };
+
             try
             {
                 // Checking to see if the user double-clicked the exe in Windows, and display a message on how to use the app


### PR DESCRIPTION
I noticed that when you manually interrupt a command like the prefill with ctrl+c, the cursor doesn't reappear which annoyed me so much, I wanted to fix it myself, so here we are. This doesn't happen when the process finishes normally.

I simply added a `Console.CancelKeyPress` handler function, which writes the ANSI escape sequence for showing the cursor, as well as a newline. For me this works perfectly fine just as intended, but feel free to test with different terminals. I'm open to any feedback, especially since this is my first contribution here and I'm not that experienced with C#.

Alternatively, in my testing I found that this is also achievable by using a `CancellationTokenSource`, which you can cancel in the `Console.CancelKeyPress` function and check in the SpectreProgress task function, to then gracefully exit the process, which lets the cleanup functions handle the cursor, just like it does when the process finishes normally. However, in this case, my approach seemed to be much easier.

If this PR gets merged, I'd like to add this or a similar fix to the other prefill repositories as well, as at least epicPrefill shows the same behaviour.
