### PR TITLE
fix: Invalid depot link causing errors

### DIFF
--- a/SteamPrefill/Handlers/DepotHandler.cs
+++ b/SteamPrefill/Handlers/DepotHandler.cs
@@ -117,9 +117,6 @@
         //TODO I don't like the fact that this has to be manually called in order to have things work correctly
         public async Task BuildLinkedDepotInfoAsync(List<DepotInfo> depots)
         {
-            // filter out any depots that link to itself instead of the original app's depot, since it fails otherwise
-            depots.RemoveAll(e => e.ManifestId == null && e.DepotFromApp.Value == e.DepotId);
-
             foreach (var depotInfo in depots.Where(e => e.ManifestId == null))
             {
                 // Shared depots will have to go get the manifest id from the original app's depot

--- a/SteamPrefill/Handlers/DepotHandler.cs
+++ b/SteamPrefill/Handlers/DepotHandler.cs
@@ -117,6 +117,9 @@
         //TODO I don't like the fact that this has to be manually called in order to have things work correctly
         public async Task BuildLinkedDepotInfoAsync(List<DepotInfo> depots)
         {
+            // filter out any depots that link to itself instead of the original app's depot, since it fails otherwise
+            depots.RemoveAll(e => e.ManifestId == null && e.DepotFromApp.Value == e.DepotId);
+
             foreach (var depotInfo in depots.Where(e => e.ManifestId == null))
             {
                 // Shared depots will have to go get the manifest id from the original app's depot

--- a/SteamPrefill/Models/DepotInfo.cs
+++ b/SteamPrefill/Models/DepotInfo.cs
@@ -37,8 +37,8 @@
         public uint? DepotFromApp { get; }
         private uint? DlcAppId { get; }
 
-        // If there is no manifest we can't download this depot, and if there is no shared depot then we can't look up a related manifest we could use
-        public bool IsInvalidDepot => ManifestId == null && DepotFromApp == null;
+        // If there is no manifest we can't download this depot, and if there is no shared depot then we can't look up a related manifest we could use. Also invalidate self-linking depots from somce DLCs that can't be downloaded.
+        public bool IsInvalidDepot => ManifestId == null && (DepotFromApp == null || DepotFromApp.Value == DepotId); 
 
         public List<OperatingSystem> SupportedOperatingSystems { get; init; } = new List<OperatingSystem>();
         public Architecture Architecture { get; init; }


### PR DESCRIPTION
I noticed that a game in my selection kept being skipped due to this error when running `prefill`:
`Unexpected download error : Sequence contains no matching element  Skipping app...`

When running `select-apps status`, it completely crashes with this long error:
```
System.InvalidOperationException: Sequence contains no matching element
  at void System.Linq.ThrowHelper.ThrowNoMatchException()                                                                                                                             
  at TSource System.Linq.Enumerable.First<TSource>(IEnumerable<TSource> source, Func<TSource, bool> predicate)                                                                        
  at async Task SteamPrefill.Handlers.DepotHandler.BuildLinkedDepotInfoAsync(List<DepotInfo> depots) in DepotHandler.cs:126                                                           
  at void SteamPrefill.SteamManager.<>c__DisplayClass20_1.<<PrintSelectedAppsStatsAsync>b__2>d.MoveNext() in SteamManager.cs:443                                                      
  at void System.Threading.Tasks.Parallel.<>c__53`1.<<ForEachAsync>b__53_0>d.MoveNext()                                                                                               
  at void SteamPrefill.SteamManager.<>c__DisplayClass20_0.<<PrintSelectedAppsStatsAsync>b__0>d.MoveNext() in SteamManager.cs:437                                                      
  at void Spectre.Console.Progress.<>c__DisplayClass31_0.<<StartAsync>b__0>d.MoveNext() in Progress.cs:103                                                                            
  at void Spectre.Console.Progress.<>c__DisplayClass32_0`1.<<StartAsync>b__0>d.MoveNext() in Progress.cs:138                                                                          
  at async Task<T> Spectre.Console.Internal.DefaultExclusivityMode.RunAsync<T>(Func<Task<T>> func) in DefaultExclusivityMode.cs:40                                                    
  at async Task<T> Spectre.Console.Progress.StartAsync<T>(Func<ProgressContext, Task<T>> action) in Progress.cs:121                                                                   
  at async Task Spectre.Console.Progress.StartAsync(Func<ProgressContext, Task> action) in Progress.cs:101                                                                            
  at async Task SteamPrefill.SteamManager.PrintSelectedAppsStatsAsync(SortOrder sortOrder, SortColumn sortColumn) in SteamManager.cs:433                                              
  at async ValueTask SteamPrefill.CliCommands.SelectAppsStatusCommand.ExecuteAsync(IConsole console) in SelectAppsStatusCommand.cs:45                                                 
  at async ValueTask<int> CliFx.CliApplication.RunAsync(ApplicationSchema applicationSchema, CommandInput commandInput) in CliApplication.cs:148                                      
  at async ValueTask<int> CliFx.CliApplication.RunAsync(IReadOnlyList<string> commandLineArguments, IReadOnlyDictionary<string, string> environmentVariables) in CliApplication.cs:190
  at async ValueTask<int> CliFx.CliApplication.RunAsync(IReadOnlyList<string> commandLineArguments) in CliApplication.cs:202                                                          
  at async Task<int> SteamPrefill.Program.Main() in Program.cs:27
```

I was able to track the problem down, turns out it was the depots for DLCs of a specific game. In this case, the depot was linking to the app id of the DLC, which is the same ID as the depotId, instead of the App ID of the actual game. This means since it was just linking to a DLC, it was unable to download a manifest, therefore throwing an error.

I'm not entirely sure, but to me it looks like the game devs just made a mistake, causing invalid metadata?

The specific depots I found that caused this for me are: 4399490, 4399590, 4399500, 4399510, and probably any other DLC for that game [City Transport Simulator 2026](https://steamdb.info/app/4148530/depots/). It's one of those games where the DLC is just an access check and the actual files for the DLC are shipped with the base game either way. Therefore each DLC has just one single depot, that's listed as unused by SteamDB.


By removing this invalid depot from the list of depots, it's simply skipped to avoid errors. Since these depots seem to be broken and a rare edge case, the negative effects from skipping it (like not having it cached, not counted towards size on select-apps status) should be negligible.

Just as last time, feel free to give feedback and correct me if I made a mistake or understood something wrong.