### PR TITLE
Fix volume mount argument in Docker-Setup-Guide.md

### DIFF
--- a/docs/mkdocs/install-guides/Docker-Setup-Guide.md
+++ b/docs/mkdocs/install-guides/Docker-Setup-Guide.md
@@ -16,7 +16,7 @@ To download and run the latest version of the container, open up a terminal and 
 
 ```bash
 docker run -it --rm --net=host \
-  --volume ~/.config/{{prefill_name}}:/Config \
+  --volume ~/.config/{{prefill_name}}:/app/Config \
   tpill90/{{repo_name}}:latest
 ```
 
@@ -29,7 +29,7 @@ At this point, you will be able to run any of the `COMMANDS` listed in the outpu
 
 ```Bash
 docker run -it --rm --net=host  \
-  --volume ~/.config/{{prefill_name}}:/Config \
+  --volume ~/.config/{{prefill_name}}:/app/Config \
   tpill90/{{repo_name}}:latest \
   select-apps
 ```


### PR DESCRIPTION
Using `--volume ~/.config/{{prefill_name}}:/Config` results in missing persistence and no data in the docker volume. After inspecting the image, I found that the Config directory is not `/Config`, but `/app/Config`. Therefore, the correct volume mount should be `--volume ~/.config/{{prefill_name}}:/app/Config`. This PR fixes the Docker Setup Guide (Docker-Setup-Guide.md). 

I tested the modified volume mount on my end, and it works as expected: persistence is working and files are written to the docker volume. 