### PR TITLE
Add `--appid` flag to prefill command

### DIFF
--- a/SteamPrefill/CliCommands/PrefillCommand.cs
+++ b/SteamPrefill/CliCommands/PrefillCommand.cs
@@ -7,6 +7,9 @@ namespace SteamPrefill.CliCommands
                                            "  Automatically includes apps selected using the 'select-apps' command")]
     public class PrefillCommand : ICommand
     {
+        [CommandOption("appid", Description = "The id of one or more apps to prefill, ignoring the apps selected using the 'select-apps' command.  AppIds can be found using https://steamdb.info/")]
+        public List<uint> AppIds { get; init; } = new List<uint>();
+
         [CommandOption("all", Description = "Prefills all currently owned games")]
         public bool DownloadAllOwnedGames { get; init; }
 
@@ -75,7 +78,8 @@ namespace SteamPrefill.CliCommands
             try
             {
                 await steamManager.InitializeAsync();
-                await steamManager.DownloadMultipleAppsAsync(DownloadAllOwnedGames,
+                await steamManager.DownloadMultipleAppsAsync(AppIds,
+                                                             DownloadAllOwnedGames,
                                                              PrefillRecentGames,
                                                              PrefillPopularGamesCount,
                                                              PrefillRecentlyPurchased);
@@ -91,7 +95,7 @@ namespace SteamPrefill.CliCommands
         {
             var userSelectedApps = steamManager.LoadPreviouslySelectedApps();
 
-            if ((DownloadAllOwnedGames) || (PrefillRecentGames) || (PrefillRecentlyPurchased) || PrefillPopularGamesCount != null || userSelectedApps.Any())
+            if (AppIds.Any() || DownloadAllOwnedGames || PrefillRecentGames || PrefillRecentlyPurchased || PrefillPopularGamesCount != null || userSelectedApps.Any())
             {
                 return;
             }
@@ -99,7 +103,7 @@ namespace SteamPrefill.CliCommands
             _ansiConsole.MarkupLine(Red("No apps have been selected for prefill! At least 1 app is required!"));
             _ansiConsole.MarkupLine(Red($"Use the {Cyan("select-apps")} command to interactively choose which apps to prefill. "));
             _ansiConsole.MarkupLine("");
-            _ansiConsole.Markup(Red($"Alternatively, the flags {LightYellow("--all")}, {LightYellow("--recent")}, {LightYellow("--recently-purchased")}, or {LightYellow("--top")} can be specified."));
+            _ansiConsole.Markup(Red($"Alternatively, the flags {LightYellow("--appid")}, {LightYellow("--all")}, {LightYellow("--recent")}, {LightYellow("--recently-purchased")}, or {LightYellow("--top")} can be specified."));
             throw new CommandException(".", 1, true);
         }
 

--- a/SteamPrefill/CliCommands/SelectAppsCommand.cs
+++ b/SteamPrefill/CliCommands/SelectAppsCommand.cs
@@ -63,7 +63,7 @@ namespace SteamPrefill.CliCommands
 
                 if (runPrefill)
                 {
-                    await steamManager.DownloadMultipleAppsAsync(false, false, null, false);
+                    await steamManager.DownloadMultipleAppsAsync(new List<uint>(), false, false, null, false);
                 }
             }
             finally

--- a/SteamPrefill/SteamManager.cs
+++ b/SteamPrefill/SteamManager.cs
@@ -67,14 +67,15 @@
         /// Given a list of AppIds, determines which apps require updates, and downloads the required depots.  By default,
         /// it will always include apps chosen by the select-apps command.
         /// </summary>
+        /// <param name="appIdsToPrefill">If any values are specified, only these apps will be downloaded, ignoring apps chosen by the select-apps command.</param>
         /// <param name="downloadAllOwnedGames">If set to true, all games owned by the user will be downloaded</param>
         /// <param name="prefillRecentGames">If set to true, games played in the last 2 weeks will be downloaded</param>
         /// <param name="prefillPopularGames">If set to a value > 0, the most popular N games will be downloaded</param>
         /// <param name="prefillRecentlyPurchasedGames">If set to true, games purchased in the last 30 days will be downloaded</param>
-        public async Task DownloadMultipleAppsAsync(bool downloadAllOwnedGames, bool prefillRecentGames,
+        public async Task DownloadMultipleAppsAsync(List<uint> appIdsToPrefill, bool downloadAllOwnedGames, bool prefillRecentGames,
                                                     int? prefillPopularGames, bool prefillRecentlyPurchasedGames)
         {
-            var appIdsToDownload = await BuildAppIdDownloadListAsync(downloadAllOwnedGames, prefillRecentGames, prefillPopularGames, prefillRecentlyPurchasedGames);
+            var appIdsToDownload = await BuildAppIdDownloadListAsync(appIdsToPrefill, downloadAllOwnedGames, prefillRecentGames, prefillPopularGames, prefillRecentlyPurchasedGames);
 
             // AppIds can potentially be added twice when building out the full list of ids
             var distinctAppIds = appIdsToDownload.Distinct().ToList();
@@ -111,15 +112,25 @@
             _prefillSummaryResult.RenderSummaryTable(_ansiConsole);
         }
 
+        /// <param name="appIdsToPrefill">If any values are specified, only these apps will be downloaded, ignoring apps chosen by the select-apps command.</param>
         /// <param name="downloadAllOwnedGames">If set to true, all games owned by the user will be downloaded</param>
         /// <param name="prefillRecentGames">If set to true, games played in the last 2 weeks will be downloaded</param>
         /// <param name="prefillPopularGames">If set to a value > 0, the most popular N games will be downloaded</param>
         /// <param name="prefillRecentlyPurchasedGames">If set to true, games purchased in the last 30 days will be downloaded</param>
-        private async Task<List<uint>> BuildAppIdDownloadListAsync(bool downloadAllOwnedGames, bool prefillRecentGames, int? prefillPopularGames,
+        private async Task<List<uint>> BuildAppIdDownloadListAsync(List<uint> appIdsToPrefill, bool downloadAllOwnedGames, bool prefillRecentGames, int? prefillPopularGames,
                                                                    bool prefillRecentlyPurchasedGames)
         {
-            // Always including selected apps
-            var appIdsToDownload = LoadPreviouslySelectedApps();
+            List<uint> appIdsToDownload;
+            if (appIdsToPrefill != null && appIdsToPrefill.Any())
+            {
+                // Specific appIds were requested, so only those apps will be downloaded, bypassing the previously selected apps list entirely.
+                appIdsToDownload = new List<uint>(appIdsToPrefill);
+            }
+            else
+            {
+                // Always including selected apps
+                appIdsToDownload = LoadPreviouslySelectedApps();
+            }
 
             // All
             if (downloadAllOwnedGames)

--- a/docs/mkdocs/detailed-command-usage/Prefill.md
+++ b/docs/mkdocs/detailed-command-usage/Prefill.md
@@ -14,7 +14,7 @@ Keeps track of which games have been previously downloaded, and will only downlo
 ## Example usage
 
 !!! Note
-    This command will automatically include any apps that have been selected using `select-apps`, regardless of any additional optional flags specified.
+    This command will automatically include any apps that have been selected using `select-apps`, regardless of any additional optional flags specified.  The exception to this is `--appid`, which will only prefill the specified app(s), ignoring the apps selected using `select-apps`.
 
 Initiating a `prefill` run is as simple as running the following from the terminal:
 ```powershell
@@ -30,6 +30,20 @@ Depending on the size of your library, and which apps you want to prefill, it ma
 
 ```powershell
 ./{{prefill_name}} prefill --all
+```
+
+### Prefilling specific app(s)
+
+Sometimes it is useful to prefill a specific game (or a small set of games), without also prefilling everything else selected using `select-apps`.  This is useful, for example, when scheduling a prefill of a specific game shortly before it will be played, without having to wait for the rest of the regularly scheduled games to be prefilled first.  Specifying `--appid` will cause **{{prefill_name}}** to only prefill the app(s) specified, ignoring any apps that were previously selected with `select-apps`.
+
+```powershell
+./{{prefill_name}} prefill --appid 730
+```
+
+More than one app can be prefilled at once, by specifying `--appid` multiple times:
+
+```powershell
+./{{prefill_name}} prefill --appid 730 --appid 440
 ```
 
 ### Ensuring your cache is fully primed
@@ -54,6 +68,7 @@ It is possible to combine multiple flags together in a single command, rather th
 
 | Option      |     | Values                | Default     |     |
 | ----------- | --- | --------------------- | ----------- | --- |
+| --appid     |     |                       |             | The id of one or more apps to prefill, ignoring the apps selected using `select-apps`. Useful for prefilling a specific game on its own. AppIds can be found using [SteamDB](https://steamdb.info/) |
 | --os        |     | windows, linux, macos | **windows** | Specifies which operating system(s) games should be downloaded for.  Typically, almost all games support Windows, however there are increasingly more games that have Linux specific game files.  In some cases, the Linux game files may be as large as the Windows version. |
 | --all       |     |                       |             | Downloads all owned apps, useful for prefilling a completely empty cache.  |
 | --recent    |     |                       |             | Adds any games played within the last 2 weeks to the download queue.  |


### PR DESCRIPTION
Closes #453.

Adds an `--appid` flag to prefill, so a specific app (or a few, by repeating the flag) can be prefilled without touching the `selectedAppsToPrefill.json` list:
```
./SteamPrefill prefill --appid 730
```

When `--appid` is used, only the given app(s) are prefilled; the selected-apps config is ignored. `--all`, `--recent`, `--top`, and `--recently-purchased` are unaffected.